### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 Zaif暗号資産取引所のAPIを[Model Context Protocol (MCP)](https://modelcontextprotocol.io/)経由で利用可能にするPythonライブラリです。ClaudeなどのLLMアシスタントから自然言語でZaif APIの機能を直接呼び出せます。
 
+<a href="https://glama.ai/mcp/servers/@curio184/zaifer-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@curio184/zaifer-mcp/badge" alt="Zaifer-MCP MCP server" />
+</a>
+
 ## ⚠️ 重要な注意事項
 
 **本アプリケーションは非公式・非公認のサードパーティ製ツールです。**


### PR DESCRIPTION
This PR adds a badge for the [Zaifer-MCP](https://glama.ai/mcp/servers/@curio184/zaifer-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@curio184/zaifer-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@curio184/zaifer-mcp/badge" alt="Zaifer-MCP MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.